### PR TITLE
fix: template is not shown in swift packages

### DIFF
--- a/MIT Swift/MIT Swift Blank Unit Test Class.xctemplate/TemplateInfo.plist
+++ b/MIT Swift/MIT Swift Blank Unit Test Class.xctemplate/TemplateInfo.plist
@@ -15,6 +15,8 @@
 	<key>DefaultCompletionName</key>
 	<string>Test</string>
 	<key>Options</key>
+	<key>SupportsSwiftPackage</key>
+	<true/>
 	<array>
 		<dict>
 			<key>Description</key>

--- a/MIT Swift/MIT Swift File.xctemplate/TemplateInfo.plist
+++ b/MIT Swift/MIT Swift File.xctemplate/TemplateInfo.plist
@@ -16,6 +16,8 @@
 	</array>
 	<key>DefaultCompletionName</key>
 	<string>File</string>
+	<key>SupportsSwiftPackage</key>
+	<true/>
 	<key>Options</key>
 	<array>
 		<dict>

--- a/MIT Swift/MIT Swift FitNesse Fixture.xctemplate/TemplateInfo.plist
+++ b/MIT Swift/MIT Swift FitNesse Fixture.xctemplate/TemplateInfo.plist
@@ -12,6 +12,8 @@
 	<string>1</string>
 	<key>DefaultCompletionName</key>
 	<string>MyFixture</string>
+	<key>SupportsSwiftPackage</key>
+	<true/>
 	<key>Options</key>
 	<array>
 		<dict>

--- a/MIT Swift/MIT Swift Mock Class.xctemplate/TemplateInfo.plist
+++ b/MIT Swift/MIT Swift Mock Class.xctemplate/TemplateInfo.plist
@@ -14,6 +14,8 @@
 	<string>Test</string>
 	<key>DefaultCompletionName</key>
 	<string>Test</string>
+	<key>SupportsSwiftPackage</key>
+	<true/>
 	<key>Options</key>
 	<array>
 		<dict>

--- a/MIT Swift/MIT Swift Unit Test Class.xctemplate/TemplateInfo.plist
+++ b/MIT Swift/MIT Swift Unit Test Class.xctemplate/TemplateInfo.plist
@@ -14,6 +14,8 @@
 	<string>Test</string>
 	<key>DefaultCompletionName</key>
 	<string>Test</string>
+	<key>SupportsSwiftPackage</key>
+	<true/>
 	<key>Options</key>
 	<array>
 		<dict>

--- a/Swift/Swift Blank Unit Test Class.xctemplate/TemplateInfo.plist
+++ b/Swift/Swift Blank Unit Test Class.xctemplate/TemplateInfo.plist
@@ -14,6 +14,8 @@
 	<string>Test</string>
 	<key>DefaultCompletionName</key>
 	<string>Test</string>
+	<key>SupportsSwiftPackage</key>
+	<true/>
 	<key>Options</key>
 	<array>
 		<dict>

--- a/Swift/Swift File.xctemplate/TemplateInfo.plist
+++ b/Swift/Swift File.xctemplate/TemplateInfo.plist
@@ -16,6 +16,8 @@
 	</array>
 	<key>DefaultCompletionName</key>
 	<string>File</string>
+	<key>SupportsSwiftPackage</key>
+	<true/>
 	<key>Options</key>
 	<array>
 		<dict>

--- a/Swift/Swift FitNesse Fixture.xctemplate/TemplateInfo.plist
+++ b/Swift/Swift FitNesse Fixture.xctemplate/TemplateInfo.plist
@@ -12,6 +12,8 @@
 	<string>1</string>
 	<key>DefaultCompletionName</key>
 	<string>MyFixture</string>
+	<key>SupportsSwiftPackage</key>
+	<true/>
 	<key>Options</key>
 	<array>
 		<dict>

--- a/Swift/Swift Mock Class.xctemplate/TemplateInfo.plist
+++ b/Swift/Swift Mock Class.xctemplate/TemplateInfo.plist
@@ -14,6 +14,8 @@
 	<string>Test</string>
 	<key>DefaultCompletionName</key>
 	<string>Test</string>
+	<key>SupportsSwiftPackage</key>
+	<true/>
 	<key>Options</key>
 	<array>
 		<dict>

--- a/Swift/Swift Unit Test Class.xctemplate/TemplateInfo.plist
+++ b/Swift/Swift Unit Test Class.xctemplate/TemplateInfo.plist
@@ -15,6 +15,8 @@
 	<key>DefaultCompletionName</key>
 	<string>Test</string>
 	<key>Options</key>
+	<key>SupportsSwiftPackage</key>
+	<true/>
 	<array>
 		<dict>
 			<key>Description</key>


### PR DESCRIPTION
there is a new field that needs to be set to make a template avaliable for the Swift Package

```
<key>SupportsSwiftPackage</key>
<true/>
```